### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,7 @@
 {
   "name": "[dev] Names generator",
   "type": "app",
+  "instance_version": "6.15.60",
   "version": "2.0.0",
   "categories": [
     "development"

--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
     "development"
   ],
   "description": "Get random names from both post response and websocket",
-  "docker_image": "supervisely/base-py-sdk:6.56.6",
+  "docker_image": "supervisely/base-py-sdk:6.73.564",
   "entrypoint": "python -m uvicorn src.main:app --host 0.0.0.0 --port 8000",
   "port": 8000,
   "task_location": "application_sessions",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-supervisely==6.56.6
+supervisely==6.73.564
 
 # for demo example
 names==0.3.0


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
